### PR TITLE
fixed parse function not returning parsed and transformed data correc…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,9 @@ function createValidator(workbook: WorkBook, opts?: ValidatorOptions) {
   const parse = (row: any, schema: ZodSchema) => {
     const data = toObject(row, header as string[])
     try {
-      schema.parse(data)
+      const parsedData = schema.parse(data)
       options.onValid && options.onValid(data)
-      return { issues: [], isValid: true, data }
+      return { issues: [], isValid: true, data: parsedData }
     } catch (error) {
       if (error instanceof ZodError) {
         options.onInvalid && options.onInvalid(data)

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -107,3 +107,48 @@ it("processes batches asynchronously", async () => {
   assert.isNotEmpty(result.valid)
   assert.isEmpty(result.invalid)
 })
+
+it("returns array of valid and transformed items", async () => {
+  const workbook = readFile(path.join(__dirname, "./mocks/demo.xls"))
+  
+  const schema = z.object({
+    "First Name": z.string(),
+    "Last Name": z.string(),
+    Gender: z.enum(["Male", "Female"]),
+    Country: z.string(),
+    Age: z.number(),
+    Date: z.preprocess((val) => String(val).replace(/\//g, "-"), z.string()).transform((val) => new Date(val)),
+    Id: z.number(),
+  })
+
+  const validator = createValidator(workbook)
+
+  const result =  await validator.validate(schema)
+
+  assert.isEmpty(result.invalid)
+  assert.isNotEmpty(result.valid)
+
+  assert.instanceOf(result.valid[0].data.Date, Date)
+})
+
+it("process and transforms batches asynchronously", async () => {
+  const workbook = readFile(path.join(__dirname, "./mocks/demo.xls"))
+
+  const schema = z.object({
+    "First Name": z.string(),
+    "Last Name": z.string(),
+    Gender: z.enum(["Male", "Female"]),
+    Country: z.string(),
+    Age: z.number(),
+    Date: z.preprocess((val) => String(val).replace(/\//g, "-"), z.string()).transform((val) => new Date(val)),
+    Id: z.number(),
+  })
+
+  const validator = createValidator(workbook)
+
+  const result = await validator.validateAsync(schema, { batchSize: 250 })
+
+  assert.isNotEmpty(result.valid)
+  assert.isEmpty(result.invalid)
+  assert.instanceOf(result.valid[0].data.Date, Date)
+})


### PR DESCRIPTION
As previously mention in #2 there is an issue causing data to be returned as it came on the original file regardless of any transformation it may have been applyed to the schema. This PR solves the problem. 