### PR TITLE
starting from index 0 instead 1 to not skip first line of content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ function createValidator(workbook: WorkBook, opts?: ValidatorOptions) {
     const batchSize = options?.batchSize ?? 500
 
     return new Promise<Result>((resolve) => {
-      let i = 1
+      let i = 0
       const result: Resource[] = []
 
       async function parseBatch() {


### PR DESCRIPTION
Using the actual index of 1, the first line of content is being ignored and not properly parsed and its content being lost